### PR TITLE
BUGFIX: parsing enddate panic

### DIFF
--- a/internal/newvm/vms.go
+++ b/internal/newvm/vms.go
@@ -20,6 +20,31 @@ type NewVmVmWrapper struct {
 	Vm Vm `json:"vm"`
 }
 
+func formatOrderEndDate(billedUntil string, now time.Time, timezone *time.Location) (string, error) {
+	billedUntil = strings.TrimSpace(billedUntil)
+	if billedUntil == "" {
+		return now.In(timezone).Format("2006-01-02"), nil
+	}
+
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.000Z07:00",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02",
+	}
+
+	var parseErr error
+	for _, layout := range layouts {
+		endDate, err := time.Parse(layout, billedUntil)
+		if err == nil {
+			return endDate.In(timezone).Format("2006-01-02"), nil
+		}
+		parseErr = err
+	}
+
+	return "", fmt.Errorf("invalid billed_until %q: %w", billedUntil, parseErr)
+}
+
 // GetVms - Returns list of available VM products (no auth required)
 func (c *Client) GetVmProducts(ctx context.Context) ([]VmProduct, error) {
 	vmProducts := []VmProduct{}
@@ -772,16 +797,19 @@ func (c *Client) DeleteVm(ctx context.Context, orderID int64) error {
 		EndDate          string `json:"end_date"`
 		IncludeSubOrders bool   `json:"includeSubOrders,omitempty"`
 	}
-	endDate, err := time.Parse("2006-01-02T15:04:05.000Z07:00", orderData.Order.BilledUntil) // this is the format for RFC3339 including milliseconds
-	if err != nil {
-		panic(err)
-	}
+
 	timezone, err := time.LoadLocation("Europe/Amsterdam")
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("load timezone: %w", err)
 	}
+
+	endDate, err := formatOrderEndDate(orderData.Order.BilledUntil, time.Now(), timezone)
+	if err != nil {
+		return fmt.Errorf("determine order end date for order %d: %w", orderID, err)
+	}
+
 	newVmOrderEnd := NewVmOrderEnd{
-		EndDate:          endDate.In(timezone).Format("2006-01-02"), // this is the format for YYYY-MM-DD
+		EndDate:          endDate, // this is the format for YYYY-MM-DD
 		IncludeSubOrders: true,
 	}
 	reqBodyOrderEnd, err := json.Marshal(newVmOrderEnd)

--- a/internal/newvm/vms_delete_test.go
+++ b/internal/newvm/vms_delete_test.go
@@ -1,0 +1,66 @@
+package newvm
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatOrderEndDate(t *testing.T) {
+	timezone, err := time.LoadLocation("Europe/Amsterdam")
+	if err != nil {
+		t.Fatalf("failed to load timezone: %v", err)
+	}
+
+	now := time.Date(2026, time.May, 29, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		billedUntil string
+		expected    string
+		wantErr     bool
+	}{
+		{
+			name:        "empty billed until falls back to now",
+			billedUntil: "",
+			expected:    "2026-05-29",
+		},
+		{
+			name:        "supports RFC3339 milliseconds",
+			billedUntil: "2026-05-30T23:59:59.000Z",
+			expected:    "2026-05-31",
+		},
+		{
+			name:        "supports RFC3339 without milliseconds",
+			billedUntil: "2026-05-30T23:59:59Z",
+			expected:    "2026-05-31",
+		},
+		{
+			name:        "supports date only",
+			billedUntil: "2026-05-30",
+			expected:    "2026-05-30",
+		},
+		{
+			name:        "invalid billed until returns error",
+			billedUntil: "not-a-date",
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatOrderEndDate(tc.billedUntil, now, timezone)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tc.expected {
+				t.Fatalf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This should fix this panic:


```
Stack trace from the terraform-provider-newvm_v1.0.19 plugin:

panic: parsing time "" as "2006-01-02T15:04:05.000Z07:00": cannot parse "" as "2006"

goroutine 82 [running]:
unithost-terraform/internal/newvm.(*Client).DeleteVm(0xc000090c60, {0x4098c58, 0xc000359aa0}, 0x976)
        /home/webapp/unithost-terraform/internal/newvm/vms.go:777 +0xbfd
unithost-terraform/internal/provider.(*vmResource).Delete(0xc00018c510, {0x4098c58, 0xc000359aa0}, {{{{0x409e150, 0xc000697aa0}, {0x3f725e0, 0xc0006972f0}}, {0x409fd48, 0xc00042d310}}, 0x0, ...}, ...)
        /home/webapp/unithost-terraform/internal/provider/resource_vm.go:596 +0x15f
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).DeleteResource(0xc0003ca008, {0x4098c58, 0xc000359aa0}, 0xc00004f440, 0xc00004f410)
        /home/webapp/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.16.1/internal/fwserver/server_deleteresource.go:124 +0x896
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ApplyResourceChange(0xc0003ca008, {0x4098c58, 0xc000359aa0}, 0xc000280150, 0xc00004f5e8)
        /home/webapp/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.16.1/internal/fwserver/server_applyresourcechange.go:91 +0x39b
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ApplyResourceChange(0xc0003ca008, {0x4098c58?, 0xc0003599b0?}, 0xc00042dc70)
        /home/webapp/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.16.1/internal/proto6server/server_applyresourcechange.go:71 +0x585
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0xc000384140, {0x4098c58?, 0xc000358ea0?}, 0xc000001c80)
        /home/webapp/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov6/tf6server/server.go:944 +0x3b9
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0x4073360, 0xc000384140}, {0x4098c58, 0xc000358ea0}, 0xc000001c00, 0x0)
        /home/webapp/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:789 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0003be000, {0x4098c58, 0xc000358e10}, 0xc00040e240, 0xc000175bf0, 0x46b9588, 0x0)
        /home/webapp/go/pkg/mod/google.golang.org/grpc@v1.75.1/server.go:1431 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc0003be000, {0x4099678, 0xc00047a000}, 0xc00040e240)
        /home/webapp/go/pkg/mod/google.golang.org/grpc@v1.75.1/server.go:1842 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /home/webapp/go/pkg/mod/google.golang.org/grpc@v1.75.1/server.go:1061 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 52
        /home/webapp/go/pkg/mod/google.golang.org/grpc@v1.75.1/server.go:1072 +0x11d

Error: The terraform-provider-newvm_v1.0.19 plugin crashed!

```