### PR TITLE
fix Provider produced inconsistent result after apply

### DIFF
--- a/internal/provider/ordermeta.go
+++ b/internal/provider/ordermeta.go
@@ -100,7 +100,12 @@ func flattenOrderMetadata(ctx context.Context, items []newvm.NewVmOrderMetaData)
 	var diags diag.Diagnostics
 
 	if len(items) == 0 {
-		return types.MapNull(types.ListType{ElemType: types.StringType}), diags
+		emptyMap, d := types.MapValue(
+			types.ListType{ElemType: types.StringType},
+			map[string]attr.Value{},
+		)
+		diags.Append(d...)
+		return emptyMap, diags
 	}
 
 	elements := make(map[string]attr.Value, len(items))

--- a/internal/provider/ordermeta_test.go
+++ b/internal/provider/ordermeta_test.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"unithost-terraform/internal/newvm"
+)
+
+func TestFlattenOrderMetadata_EmptyIsTypedEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	meta, diags := flattenOrderMetadata(context.Background(), []newvm.NewVmOrderMetaData{})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics errors: %v", diags.Errors())
+	}
+
+	if meta.IsNull() {
+		t.Fatalf("expected metadata to be an empty map, got null")
+	}
+
+	if meta.IsUnknown() {
+		t.Fatalf("expected metadata to be known, got unknown")
+	}
+
+	if got := len(meta.Elements()); got != 0 {
+		t.Fatalf("expected 0 metadata elements, got %d", got)
+	}
+}


### PR DESCRIPTION
fix this:

```
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to module.vms.newvm_vm.this["app01"], provider "provider[\"registry.terraform.io/newvmcloud/newvm\"]" produced an
│ unexpected new value: .metadata: was cty.MapValEmpty(cty.List(cty.String)), but now null.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Error Deleting VM
│ 
│ Could not delete VM, unexpected error: no VM found in result
```